### PR TITLE
Update RPi_Pico_TimerInterrupt.h

### DIFF
--- a/src/RPi_Pico_TimerInterrupt.h
+++ b/src/RPi_Pico_TimerInterrupt.h
@@ -124,6 +124,7 @@ class RPI_PICO_TimerInterrupt
     {
       _timerNo  = timerNo;
       _callback = NULL;
+      memset(&_timer,0,sizeof(repeating_timer));
     };
 
     ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Uninitialized repeating_timer struct leading to crash in certain situations.

The following way of creating the **RPI_Pico_Timer** object will result in a crash due to the **repeating_timer** struct (private member) being left with completely random values.

The crash happens in `setFrequency(...)` line [165](https://github.com/git2212/RPI_PICO_TimerInterrupt/blob/45c4aca9e9c6b13c87772ef28c1d333106fda47a/src/RPi_Pico_TimerInterrupt.h#L165) when an attempt is made to cancel a non existing timer.

This patch is a solution to the problem.